### PR TITLE
Force filter-branch to avoid error

### DIFF
--- a/providers/coding_standard.rb
+++ b/providers/coding_standard.rb
@@ -34,7 +34,7 @@ action :install do
 
   execute 'filter-subdirectory' do
     cwd target
-    command "git filter-branch --subdirectory-filter #{new_resource.subdirectory}"
+    command "git filter-branch --subdirectory-filter -f #{new_resource.subdirectory}"
     not_if { new_resource.subdirectory.nil? }
     action :nothing
   end


### PR DESCRIPTION
Cannot create a new backup.
A previous backup already exists in refs/original/
Force overwriting the backup with -f
