### PR TITLE
fix argument error thrown in Chef 13

### DIFF
--- a/resources/coding_standard.rb
+++ b/resources/coding_standard.rb
@@ -8,7 +8,7 @@
 actions :install
 default_action :install
 
-attribute :name, :name_attribute => true, :kind_of => String, :default => nil
+attribute :name, :name_attribute => true, :kind_of => String
 attribute :repository, :kind_of => String, :default => nil
 attribute :reference, :kind_of => String, :default => nil
 attribute :subdirectory, :kind_of => String, :default => nil


### PR DESCRIPTION
When compiling cookbooks in Chef 13, the following argument error is thrown:

Cannot specify both default and name_property/name_attribute together on
property name of resource phpcs_coding_standard

Removing the default declaration resolves the error.